### PR TITLE
Add more compilers, don't pass -it unless in interactive terminal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,18 @@ FROM ubuntu:20.10
  ARG GROUP_ID
 # We install some useful packages
  RUN apt-get update -qq
- RUN DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata gnuplot
- RUN apt-get install -y vim valgrind golang llvm gdb lldb clang-format sudo pip python python-dev wget cmake g++ g++-9 git clang++-9 linux-tools-generic ruby ruby-dev python3-pip  libboost-all-dev
 
+ RUN DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata gnuplot
+ RUN apt-get install -y vim valgrind golang llvm gdb lldb clang-format sudo pip python python-dev wget cmake g++ g++-9 git clang++-9 linux-tools-generic ruby ruby-dev python3-pip  libboost-all-dev git
  RUN  pip3 install ipython
+
+# Moar compilers
+ RUN apt-get install -y clang++-6
+ RUN apt-get install -y clang++-7
+ RUN apt-get install -y clang++-8
+ RUN apt-get install -y clang++-9
+ RUN apt-get install -y g++-7 g++-8 g++-9 g++-10
+ RUN apt-get install -y ruby
 
  RUN addgroup --gid $GROUP_ID user; exit 0
  RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID $USER_NAME; exit 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ FROM ubuntu:20.10
  RUN apt-get install -y clang++-7
  RUN apt-get install -y clang++-8
  RUN apt-get install -y clang++-9
+ RUN apt-get install -y clang++-10
+ RUN apt-get install -y clang++-11
  RUN apt-get install -y g++-7 g++-8 g++-9 g++-10
  RUN apt-get install -y ruby
 

--- a/command-docker-station
+++ b/command-docker-station
@@ -27,7 +27,7 @@ SSHPARAM=""
 docker image inspect $container_name >/dev/null 2>&1 || ( echo "instantiating the container" ; docker build --no-cache -t $container_name -f $SCRIPTPATH/Dockerfile --build-arg USER_NAME="$USER"  --build-arg USER_ID=$(id -u)  --build-arg GROUP_ID=$(id -g) .  )
 
 # We run in privileged mode to have access to performance counters.
-docker run --rm -h $container_name --privileged $SSHPARAM -v $(pwd):$(pwd):Z  -w $(pwd)  $container_name sh -c "$COMMAND"
-
+if [ -t 0 ] ; then DOCKER_ARGS=-it; fi
+docker run --rm $DOCKER_ARGS -h $container_name --privileged $SSHPARAM -v $(pwd):$(pwd):Z  -w $(pwd)  $container_name sh -c "$COMMAND"
 
 

--- a/run-docker-station
+++ b/run-docker-station
@@ -27,7 +27,8 @@ SSHPARAM=""
 docker image inspect $container_name >/dev/null 2>&1 || ( echo "instantiating the container" ; docker build --no-cache -t $container_name -f $SCRIPTPATH/Dockerfile --build-arg USER_NAME="$USER"  --build-arg USER_ID=$(id -u)  --build-arg GROUP_ID=$(id -g) .  )
 
 # We run in privileged mode to have access to performance counters.
-docker run --rm -it -h $container_name --privileged $SSHPARAM -v $(pwd):$(pwd):Z  -w $(pwd)  $container_name sh -c "$COMMAND"
+if [ -t 0 ]; then DOCKER_ARGS=-it; fi
+docker run --rm $DOCKER_ARGS -h $container_name --privileged $SSHPARAM -v $(pwd):$(pwd):Z  -w $(pwd)  $container_name sh -c "$COMMAND"
 
 
 


### PR DESCRIPTION
This makes it so I can run the benchmarks with one ssh command from my workstation:

```bash
ssh skylake.<redacted> cd ~/simdjson_benchmark_results \&\& ~/docker_programming_station/run-docker-station ./run_benchmark_official.sh skylake v0.8.0 v0.8.0 clang11
```